### PR TITLE
Add mixin for realms disconnect screen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ loader_version=0.16.9
 
 
 # Mod Properties
-mod_version = 0.2.0
+mod_version = 0.2.3
 maven_group = com.connorcode
 archives_base_name = auto-reauth
 

--- a/src/main/java/com/connorcode/autoreauth/mixin/DisconnectedRealmsScreenMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/DisconnectedRealmsScreenMixin.java
@@ -1,0 +1,33 @@
+package com.connorcode.autoreauth.mixin;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.realms.gui.screen.DisconnectedRealmsScreen;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static com.connorcode.autoreauth.Reauth.*;
+
+@Mixin(DisconnectedRealmsScreen.class)
+public class DisconnectedRealmsScreenMixin extends Screen {
+    protected DisconnectedRealmsScreenMixin(Text title) {
+        super(title);
+        throw new UnsupportedOperationException("Mixin constructor");
+    }
+
+    @Inject(at = @At("TAIL"), method = "<init>")
+    void onInit(CallbackInfo ci) {
+        refreshAuthStatus();
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        super.render(context, mouseX, mouseY, delta);
+        renderAuthStatus(context);
+    }
+
+    // Note: tick method is in MinecraftClientMixin
+}

--- a/src/main/java/com/connorcode/autoreauth/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/MinecraftClientMixin.java
@@ -3,6 +3,7 @@ package com.connorcode.autoreauth.mixin;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.DisconnectedScreen;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.realms.gui.screen.DisconnectedRealmsScreen;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,6 +22,9 @@ public class MinecraftClientMixin {
     @Inject(at = @At("HEAD"), method = "tick")
     void onTick(CallbackInfo ci) {
         // So janky sob but it's needed for meteor client compat
-        if (this.currentScreen instanceof DisconnectedScreen) tickAuthStatus(this.currentScreen);
+        if (this.currentScreen instanceof DisconnectedScreen 
+                || this.currentScreen instanceof DisconnectedRealmsScreen) {
+            tickAuthStatus(this.currentScreen);
+        }
     }
 }

--- a/src/main/resources/auto-reauth.mixins.json
+++ b/src/main/resources/auto-reauth.mixins.json
@@ -7,6 +7,7 @@
   ],
   "client": [
     "ConnectScreenMixin",
+    "DisconnectedRealmsScreenMixin",
     "DisconnectedScreenMixin",
     "MinecraftClientMixin",
     "MultiplayerScreenMixin",


### PR DESCRIPTION
This PR copies the `DisconnectedScreenMixin` code to allow reauth to work on disconnection from realms.